### PR TITLE
Remaining changes to support epp-client port (in particular, inline mode)

### DIFF
--- a/instant-xml-macros/src/case.rs
+++ b/instant-xml-macros/src/case.rs
@@ -95,7 +95,11 @@ impl RenameRule {
 
     /// Apply a renaming rule to a struct field, returning the version expected in the source.
     pub fn apply_to_field(&self, ident: &Ident) -> String {
-        let field = ident.to_string();
+        let mut field = ident.to_string();
+        if field.starts_with("r#") {
+            field = field[2..].to_string();
+        }
+
         match *self {
             None | LowerCase | SnakeCase => field,
             UpperCase => field.to_ascii_uppercase(),

--- a/instant-xml-macros/src/lib.rs
+++ b/instant-xml-macros/src/lib.rs
@@ -54,7 +54,7 @@ impl<'input> ContainerMeta<'input> {
                 }
                 MetaItem::Mode(new) => match mode {
                     None => mode = Some(new),
-                    Some(_) => return Err(syn::Error::new(span, "cannot have two enum modes")),
+                    Some(_) => return Err(syn::Error::new(span, "cannot have two modes")),
                 },
                 _ => {
                     return Err(syn::Error::new(
@@ -302,6 +302,7 @@ fn discard_path_lifetimes(
 enum Mode {
     Forward,
     Scalar,
+    Transparent,
 }
 
 #[cfg(test)]
@@ -334,7 +335,7 @@ mod tests {
             }
         })
         .to_string())
-        .find("compile_error ! { \"missing enum mode\" }")
+        .find("compile_error ! { \"missing mode\" }")
         .unwrap();
     }
 

--- a/instant-xml-macros/src/meta.rs
+++ b/instant-xml-macros/src/meta.rs
@@ -298,6 +298,9 @@ pub(crate) fn meta_items(attrs: &[syn::Attribute]) -> Vec<(MetaItem, Span)> {
                 } else if id == "direct" {
                     items.push((MetaItem::Direct, span));
                     MetaState::Comma
+                } else if id == "transparent" {
+                    items.push((MetaItem::Mode(Mode::Transparent), span));
+                    MetaState::Comma
                 } else if id == "ns" {
                     MetaState::Ns
                 } else if id == "rename" {

--- a/instant-xml/src/de.rs
+++ b/instant-xml/src/de.rs
@@ -333,8 +333,9 @@ impl<'xml> Iterator for Context<'xml> {
 }
 
 pub fn borrow_cow_str<'xml>(
-    deserializer: &mut Deserializer<'_, 'xml>,
     into: &mut Option<Cow<'xml, str>>,
+    _: &'static str,
+    deserializer: &mut Deserializer<'_, 'xml>,
 ) -> Result<(), Error> {
     if into.is_some() {
         return Err(Error::DuplicateValue);
@@ -349,8 +350,9 @@ pub fn borrow_cow_str<'xml>(
 }
 
 pub fn borrow_cow_slice_u8<'xml>(
-    deserializer: &mut Deserializer<'_, 'xml>,
     into: &mut Option<Cow<'xml, [u8]>>,
+    _: &'static str,
+    deserializer: &mut Deserializer<'_, 'xml>,
 ) -> Result<(), Error> {
     if into.is_some() {
         return Err(Error::DuplicateValue);

--- a/instant-xml/src/de.rs
+++ b/instant-xml/src/de.rs
@@ -31,12 +31,15 @@ impl<'cx, 'xml> Deserializer<'cx, 'xml> {
     }
 
     pub fn take_str(&mut self) -> Result<Option<&'xml str>, Error> {
-        match self.next() {
-            Some(Ok(Node::AttributeValue(s))) => Ok(Some(s)),
-            Some(Ok(Node::Text(s))) => Ok(Some(s)),
-            Some(Ok(node)) => Err(Error::ExpectedScalar(format!("{node:?}"))),
-            Some(Err(e)) => Err(e),
-            None => Ok(None),
+        loop {
+            match self.next() {
+                Some(Ok(Node::AttributeValue(s))) => return Ok(Some(s)),
+                Some(Ok(Node::Text(s))) => return Ok(Some(s)),
+                Some(Ok(Node::Attribute(_))) => continue,
+                Some(Ok(node)) => return Err(Error::ExpectedScalar(format!("{node:?}"))),
+                Some(Err(e)) => return Err(e),
+                None => return Ok(None),
+            }
         }
     }
 

--- a/instant-xml/src/impls.rs
+++ b/instant-xml/src/impls.rs
@@ -375,6 +375,12 @@ pub struct OptionAccumulator<T, A: Accumulate<T>> {
     marker: PhantomData<T>,
 }
 
+impl<T, A: Accumulate<T>> OptionAccumulator<T, A> {
+    pub fn get_mut(&mut self) -> &mut A {
+        &mut self.value
+    }
+}
+
 impl<T, A: Accumulate<T>> Default for OptionAccumulator<T, A> {
     fn default() -> Self {
         Self {

--- a/instant-xml/src/lib.rs
+++ b/instant-xml/src/lib.rs
@@ -40,8 +40,9 @@ pub trait FromXml<'xml>: Sized {
     fn matches(id: Id<'_>, field: Option<Id<'_>>) -> bool;
 
     fn deserialize<'cx>(
-        deserializer: &mut Deserializer<'cx, 'xml>,
         into: &mut Self::Accumulator,
+        field: &'static str,
+        deserializer: &mut Deserializer<'cx, 'xml>,
     ) -> Result<(), Error>;
 
     type Accumulator: Accumulate<Self>;
@@ -86,8 +87,12 @@ pub fn from_str<'xml, T: FromXml<'xml>>(input: &'xml str) -> Result<T, Error> {
     }
 
     let mut value = T::Accumulator::default();
-    T::deserialize(&mut Deserializer::new(root, &mut context), &mut value)?;
-    value.try_done("root element")
+    T::deserialize(
+        &mut value,
+        "<root element>",
+        &mut Deserializer::new(root, &mut context),
+    )?;
+    value.try_done("<root element>")
 }
 
 pub fn to_string(value: &(impl ToXml + ?Sized)) -> Result<String, Error> {

--- a/instant-xml/src/lib.rs
+++ b/instant-xml/src/lib.rs
@@ -9,7 +9,7 @@ pub mod de;
 mod impls;
 use de::Context;
 pub use de::Deserializer;
-pub use impls::{display_to_xml, from_xml_str};
+pub use impls::{display_to_xml, from_xml_str, OptionAccumulator};
 #[doc(hidden)]
 pub mod ser;
 pub use ser::Serializer;

--- a/instant-xml/tests/de-nested.rs
+++ b/instant-xml/tests/de-nested.rs
@@ -13,7 +13,7 @@ struct NestedDe {
 #[xml(ns("URI", bar = "BAZ", foo = "BAR"))]
 struct StructWithCustomFieldFromXml {
     #[xml(ns(BAR))]
-    flag: bool,
+    r#flag: bool,
     #[xml(attribute)]
     flag_attribute: bool,
     test: NestedDe,

--- a/instant-xml/tests/entities.rs
+++ b/instant-xml/tests/entities.rs
@@ -31,7 +31,7 @@ fn escape_back() {
         from_str(
             "<StructSpecialEntities xmlns=\"URI\"><string>&lt;&gt;&amp;&quot;&apos;adsad&quot;</string><str>str&amp;</str></StructSpecialEntities>"
         ),
-        Err::<StructSpecialEntities, _>(Error::UnexpectedValue("string with escape characters cannot be deserialized as &str: 'str&amp;'".to_owned()))
+        Err::<StructSpecialEntities, _>(Error::UnexpectedValue("string with escape characters cannot be deserialized as &str for StructSpecialEntities::str: 'str&amp;'".to_owned()))
     );
 
     // Borrowed

--- a/instant-xml/tests/scalar.rs
+++ b/instant-xml/tests/scalar.rs
@@ -74,3 +74,21 @@ fn scalars() {
         })
     );
 }
+
+#[derive(Debug, FromXml, PartialEq)]
+struct ScalarElementAttr {
+    s: String,
+}
+
+#[test]
+fn scalar_element_attr() {
+    assert_eq!(
+        from_str::<ScalarElementAttr>(
+            "<ScalarElementAttr><s lang=\"en\">hello</s></ScalarElementAttr>"
+        )
+        .unwrap(),
+        ScalarElementAttr {
+            s: "hello".to_string(),
+        }
+    );
+}

--- a/instant-xml/tests/transparent.rs
+++ b/instant-xml/tests/transparent.rs
@@ -1,4 +1,6 @@
-use instant_xml::{from_str, to_string, FromXml, ToXml};
+use similar_asserts::assert_eq;
+
+use instant_xml::{from_str, to_string, Error, FromXml, ToXml};
 
 #[derive(Debug, Eq, FromXml, PartialEq, ToXml)]
 struct Wrapper {
@@ -36,4 +38,10 @@ fn inline() {
     let xml = r#"<Wrapper><Foo><i>42</i></Foo><Bar><s>hello</s></Bar></Wrapper>"#;
     assert_eq!(xml, to_string(&v).unwrap());
     assert_eq!(v, from_str(xml).unwrap());
+
+    assert_eq!(
+        from_str::<Wrapper>("<Wrapper><Foo><i>42</i><Bar><s>hello</s></Bar></Foo></Wrapper>")
+            .unwrap_err(),
+        Error::MissingValue("Inline::bar")
+    );
 }

--- a/instant-xml/tests/transparent.rs
+++ b/instant-xml/tests/transparent.rs
@@ -1,0 +1,37 @@
+use instant_xml::{to_string, ToXml};
+
+#[derive(Debug, Eq, PartialEq, ToXml)]
+struct Wrapper {
+    inline: Inline,
+}
+
+#[derive(Debug, Eq, PartialEq, ToXml)]
+#[xml(transparent)]
+struct Inline {
+    foo: Foo,
+    bar: Bar,
+}
+
+#[derive(Debug, Eq, PartialEq, ToXml)]
+struct Foo {
+    i: u8,
+}
+
+#[derive(Debug, Eq, PartialEq, ToXml)]
+struct Bar {
+    s: String,
+}
+
+#[test]
+fn inline() {
+    let v = Wrapper {
+        inline: Inline {
+            foo: Foo { i: 42 },
+            bar: Bar {
+                s: "hello".to_string(),
+            },
+        },
+    };
+    let xml = r#"<Wrapper><Foo><i>42</i></Foo><Bar><s>hello</s></Bar></Wrapper>"#;
+    assert_eq!(xml, to_string(&v).unwrap());
+}

--- a/instant-xml/tests/transparent.rs
+++ b/instant-xml/tests/transparent.rs
@@ -1,23 +1,23 @@
-use instant_xml::{to_string, ToXml};
+use instant_xml::{from_str, to_string, FromXml, ToXml};
 
-#[derive(Debug, Eq, PartialEq, ToXml)]
+#[derive(Debug, Eq, FromXml, PartialEq, ToXml)]
 struct Wrapper {
     inline: Inline,
 }
 
-#[derive(Debug, Eq, PartialEq, ToXml)]
+#[derive(Debug, Eq, FromXml, PartialEq, ToXml)]
 #[xml(transparent)]
 struct Inline {
     foo: Foo,
     bar: Bar,
 }
 
-#[derive(Debug, Eq, PartialEq, ToXml)]
+#[derive(Debug, Eq, FromXml, PartialEq, ToXml)]
 struct Foo {
     i: u8,
 }
 
-#[derive(Debug, Eq, PartialEq, ToXml)]
+#[derive(Debug, Eq, FromXml, PartialEq, ToXml)]
 struct Bar {
     s: String,
 }
@@ -32,6 +32,8 @@ fn inline() {
             },
         },
     };
+
     let xml = r#"<Wrapper><Foo><i>42</i></Foo><Bar><s>hello</s></Bar></Wrapper>"#;
     assert_eq!(xml, to_string(&v).unwrap());
+    assert_eq!(v, from_str(xml).unwrap());
 }


### PR DESCRIPTION
Inline mode can be used for (de)serializing a group of elements together, without wrapping it in a shared parent element. This is necessary for EPP extensions, where we sometimes need to deal with multiple extensions inside an `<extension>` tag.

@valkum I can imagine you don't want to do a very detailed review of this, but please look at the test cases and see if things conceptually make sense to you. These are the remaining changes needed to get the instant-epp tests to pass.