### PR TITLE
Bump version to 0.2

### DIFF
--- a/instant-xml-macros/Cargo.toml
+++ b/instant-xml-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "instant-xml-macros"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.58"
 workspace = ".."

--- a/instant-xml/Cargo.toml
+++ b/instant-xml/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "instant-xml"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.58"
 workspace = ".."
@@ -11,7 +11,7 @@ repository = "https://github.com/InstantDomain/instant-xml"
 
 [dependencies]
 chrono = { version = "0.4.23", optional = true }
-macros = { package = "instant-xml-macros", version = "0.1", path = "../instant-xml-macros" }
+macros = { package = "instant-xml-macros", version = "0.2", path = "../instant-xml-macros" }
 thiserror = "1.0.29"
 xmlparser = "0.13.3"
 


### PR DESCRIPTION
Bump the version in anticipation of publishing for use in instant-epp. #39 changed the public API so bumping directly to 0.2.