### PR TITLE
Refer to README from Cargo metadata

### DIFF
--- a/instant-xml-macros/Cargo.toml
+++ b/instant-xml-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "instant-xml-macros"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 rust-version = "1.58"
 workspace = ".."

--- a/instant-xml-macros/Cargo.toml
+++ b/instant-xml-macros/Cargo.toml
@@ -8,6 +8,7 @@ license = "Apache-2.0 OR MIT"
 description = "Procedural macros for instant-xml"
 documentation = "https://docs.rs/instant-xml-macros"
 repository = "https://github.com/InstantDomain/instant-xml"
+readme = "../README.md"
 
 [lib]
 proc-macro = true

--- a/instant-xml/Cargo.toml
+++ b/instant-xml/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "instant-xml"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 rust-version = "1.58"
 workspace = ".."

--- a/instant-xml/Cargo.toml
+++ b/instant-xml/Cargo.toml
@@ -8,6 +8,7 @@ license = "Apache-2.0 OR MIT"
 description = "A more rigorous way to map XML to Rust types"
 documentation = "https://docs.rs/instant-xml"
 repository = "https://github.com/InstantDomain/instant-xml"
+readme = "../README.md"
 
 [dependencies]
 chrono = { version = "0.4.23", optional = true }


### PR DESCRIPTION
With version bumps so we can publish a version that has the README.